### PR TITLE
Vite actions - pack Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,14 +76,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   pack-windows: # When there is a tag, pack the installers and upload to Github.
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     env:
       VITE_API_URL: ${{ secrets.API_URL }}
       VITE_PB_APP_URL: ${{ secrets.APP_URL }}
       VITE_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
       VITE_VERSION: ${{github.ref_name}}
-      'CommonProgramFiles(x86)': "%COMMONPROGRAMFILES%"
-      'ProgramFiles(x86)': "%PROGRAMFILES%"
     if: startsWith(github.ref, 'refs/tags')
     needs: test
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,8 @@ jobs:
       VITE_PB_APP_URL: ${{ secrets.APP_URL }}
       VITE_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
       VITE_VERSION: ${{github.ref_name}}
+      'CommonProgramFiles(x86)': "%COMMONPROGRAMFILES%"
+      'ProgramFiles(x86)': "%PROGRAMFILES%"
     if: startsWith(github.ref, 'refs/tags')
     needs: test
     steps:
@@ -101,10 +103,10 @@ jobs:
   publish-surge: # When there is a push in develop, publish on surge
     runs-on: ubuntu-latest
     env:
-      VITE_APP_API_URL: ${{ secrets.API_URL }}
-      VITE_APP_PB_APP_URL: ${{ secrets.APP_URL }}
-      VITE_APP_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
-      VITE_APP_VERSION: ${{github.ref_name}}
+      VITE_API_URL: ${{ secrets.API_URL }}
+      VITE_PB_APP_URL: ${{ secrets.APP_URL }}
+      VITE_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
+      VITE_VERSION: ${{github.ref_name}}
     if: false 
     #github.event_name == 'push' && github.ref == 'refs/heads/develop'
     needs: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,10 @@ jobs:
   pack-linux: # When there is a tag, pack the installers and upload to Github.
       runs-on: ubuntu-latest
       env:
-        VITE_APP_API_URL: ${{ secrets.API_URL }}
-        VITE_APP_PB_APP_URL: ${{ secrets.APP_URL }}
-        VITE_APP_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
-        VITE_APP_VERSION: ${{github.ref_name}}
+        VITE_API_URL: ${{ secrets.API_URL }}
+        VITE_PB_APP_URL: ${{ secrets.APP_URL }}
+        VITE_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
+        VITE_VERSION: ${{github.ref_name}}
       if: startsWith(github.ref, 'refs/tags')
       needs: test
       steps:
@@ -55,10 +55,10 @@ jobs:
   pack-macos: # When there is a tag, pack the installers and upload to Github.
     runs-on: macos-latest
     env:
-      VITE_APP_API_URL: ${{ secrets.API_URL }}
-      VITE_APP_PB_APP_URL: ${{ secrets.APP_URL }}
-      VITE_APP_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
-      VITE_APP_VERSION: ${{github.ref_name}}
+      VITE_API_URL: ${{ secrets.API_URL }}
+      VITE_PB_APP_URL: ${{ secrets.APP_URL }}
+      VITE_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
+      VITE_VERSION: ${{github.ref_name}}
     if: startsWith(github.ref, 'refs/tags')
     needs: test
     steps:
@@ -78,10 +78,10 @@ jobs:
   pack-windows: # When there is a tag, pack the installers and upload to Github.
     runs-on: windows-latest
     env:
-      VITE_APP_API_URL: ${{ secrets.API_URL }}
-      VITE_APP_PB_APP_URL: ${{ secrets.APP_URL }}
-      VITE_APP_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
-      VITE_APP_VERSION: ${{github.ref_name}}
+      VITE_API_URL: ${{ secrets.API_URL }}
+      VITE_PB_APP_URL: ${{ secrets.APP_URL }}
+      VITE_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
+      VITE_VERSION: ${{github.ref_name}}
     if: startsWith(github.ref, 'refs/tags')
     needs: test
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pilasbloques",
-      "version": "2.5.8",
+      "version": "2.5.7",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pilasbloques",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pilasbloques",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.7",
+  "version": "2.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.8",
+  "version": "2.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pilasbloques",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.8",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.8",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -53,6 +53,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest-resolve": "^27.4.2",
         "jest-watch-typeahead": "^2.2.2",
+        "makensis": "^2.0.8",
         "mini-css-extract-plugin": "^2.4.5",
         "pilas-bloques-exercises": "^1.4.31",
         "postcss": "^8.4.4",
@@ -99,7 +100,6 @@
         "fetch-mock-jest": "^1.5.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "makensis": "^2.0.5",
         "react-markdown": "^8.0.7",
         "release-it": "^15.6.0",
         "remark-emoji": "^3.1.2",
@@ -17500,12 +17500,13 @@
       }
     },
     "node_modules/makensis": {
-      "version": "2.0.5",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/makensis/-/makensis-2.0.8.tgz",
+      "integrity": "sha512-DEwR7EHnRAQEx5cgvLzHiIjwH471wEfJasa2mTMLuW6byYgY6F+87TiSj8n8C5OYtBCQwA8Fd6S7N0I5ayTvKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nsis/language-data": "^0.9.0",
-        "dotenv": "^16.0.3",
+        "dotenv": "^16.3.1",
         "dotenv-expand": "^10.0.0"
       },
       "engines": {
@@ -38480,11 +38481,13 @@
       }
     },
     "makensis": {
-      "version": "2.0.5",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/makensis/-/makensis-2.0.8.tgz",
+      "integrity": "sha512-DEwR7EHnRAQEx5cgvLzHiIjwH471wEfJasa2mTMLuW6byYgY6F+87TiSj8n8C5OYtBCQwA8Fd6S7N0I5ayTvKQ==",
       "dev": true,
       "requires": {
         "@nsis/language-data": "^0.9.0",
-        "dotenv": "^16.0.3",
+        "dotenv": "^16.3.1",
         "dotenv-expand": "^10.0.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pilasbloques",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "productName": "Pilas Bloques",
   "genericName": "Programacion con bloques",
   "description": "Una herramienta para aprender a programar utilizando bloques",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.8",
+  "version": "2.5.6",
   "productName": "Pilas Bloques",
   "genericName": "Programacion con bloques",
   "description": "Una herramienta para aprender a programar utilizando bloques",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.7",
+  "version": "2.5.6",
   "productName": "Pilas Bloques",
   "genericName": "Programacion con bloques",
   "description": "Una herramienta para aprender a programar utilizando bloques",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "productName": "Pilas Bloques",
   "genericName": "Programacion con bloques",
   "description": "Una herramienta para aprender a programar utilizando bloques",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.8",
+  "version": "2.5.7",
   "productName": "Pilas Bloques",
   "genericName": "Programacion con bloques",
   "description": "Una herramienta para aprender a programar utilizando bloques",
@@ -55,6 +55,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest-resolve": "^27.4.2",
     "jest-watch-typeahead": "^2.2.2",
+    "makensis": "^2.0.8",
     "mini-css-extract-plugin": "^2.4.5",
     "pilas-bloques-exercises": "^1.4.31",
     "postcss": "^8.4.4",
@@ -140,7 +141,6 @@
     "fetch-mock-jest": "^1.5.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "makensis": "^2.0.5",
     "react-markdown": "^8.0.7",
     "release-it": "^15.6.0",
     "remark-emoji": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "productName": "Pilas Bloques",
   "genericName": "Programacion con bloques",
   "description": "Una herramienta para aprender a programar utilizando bloques",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "productName": "Pilas Bloques",
   "genericName": "Programacion con bloques",
   "description": "Una herramienta para aprender a programar utilizando bloques",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilasbloques",
-  "version": "2.5.8",
+  "version": "2.5.7",
   "productName": "Pilas Bloques",
   "genericName": "Programacion con bloques",
   "description": "Una herramienta para aprender a programar utilizando bloques",

--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,4 @@
-VITE_APP_API_URL=http://localhost:3001
-VITE_APP_PB_APP_URL=http://localhost:3000
-VITE_APP_VERSION=$npm_package_version
-VITE_APP_GOOGLE_ANALYTICS_KEY=G-xxxxxx #Not necessary, can be omitted for development
+VITE_API_URL=http://localhost:3001
+VITE_PB_APP_URL=http://localhost:3000
+VITE_VERSION=$npm_package_version
+VITE_GOOGLE_ANALYTICS_KEY=G-xxxxxx #Not necessary, can be omitted for development

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -77,6 +77,7 @@ osx() {
 windows_exe() {
     eco "Generating installer for windows..."
     sudo apt install wine64
+    npm install makensis
     pack "win32" "ia32" "ico"
 	cp packaging/instalador.nsi binaries/$NAME-win32-ia32/
 	cd binaries/$NAME-win32-ia32/; makensis instalador.nsi; cd ../..

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -77,7 +77,7 @@ osx() {
 windows_exe() {
     eco "Generating installer for windows..."
     sudo apt install wine64
-    npm install makensis
+    sudo apt install nsis
     pack "win32" "ia32" "ico"
 	cp packaging/instalador.nsi binaries/$NAME-win32-ia32/
 	cd binaries/$NAME-win32-ia32/; makensis instalador.nsi; cd ../..

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -76,6 +76,7 @@ osx() {
 
 windows_exe() {
     eco "Generating installer for windows..."
+    sudo apt install wine64
     pack "win32" "ia32" "ico"
 	cp packaging/instalador.nsi binaries/$NAME-win32-ia32/
 	cd binaries/$NAME-win32-ia32/; makensis instalador.nsi; cd ../..

--- a/src/components/creator/Editor/ActionButtons/ShareChallenge/ShareButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/ShareChallenge/ShareButton.tsx
@@ -34,7 +34,7 @@ const ShareDialog = ({ open, setDialogOpen }: { open: boolean, setDialogOpen: (o
 export const ShareModal = () => {
     const { sharedId } = useContext(CreatorContext)
     
-    const sharedLink = import.meta.env.VITE_PB_APP_URL  + `/#/desafio/guardado/${sharedId}`
+    const sharedLink = process.env.VITE_PB_APP_URL  + `/#/desafio/guardado/${sharedId}`
 
     return <Stack>
         {sharedId ?

--- a/src/components/creator/Editor/ActionButtons/ShareChallenge/ShareButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/ShareChallenge/ShareButton.tsx
@@ -34,7 +34,7 @@ const ShareDialog = ({ open, setDialogOpen }: { open: boolean, setDialogOpen: (o
 export const ShareModal = () => {
     const { sharedId } = useContext(CreatorContext)
     
-    const sharedLink = process.env.VITE_APP_PB_APP_URL  + `/#/desafio/guardado/${sharedId}`
+    const sharedLink = process.env.VITE_PB_APP_URL  + `/#/desafio/guardado/${sharedId}`
 
     return <Stack>
         {sharedId ?

--- a/src/components/creator/Editor/ActionButtons/ShareChallenge/ShareButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/ShareChallenge/ShareButton.tsx
@@ -34,7 +34,7 @@ const ShareDialog = ({ open, setDialogOpen }: { open: boolean, setDialogOpen: (o
 export const ShareModal = () => {
     const { sharedId } = useContext(CreatorContext)
     
-    const sharedLink = process.env.VITE_PB_APP_URL  + `/#/desafio/guardado/${sharedId}`
+    const sharedLink = import.meta.env.VITE_PB_APP_URL  + `/#/desafio/guardado/${sharedId}`
 
     return <Stack>
         {sharedId ?

--- a/src/components/creator/Editor/ChallengeDetailsEdition/ToolBoxEditor/ToolBoxEditor.tsx
+++ b/src/components/creator/Editor/ChallengeDetailsEdition/ToolBoxEditor/ToolBoxEditor.tsx
@@ -12,7 +12,7 @@ import { availableBlocksFor, categories } from "../../../../blockly/blocks";
 
 export const ToolBoxEditor = () => {
 
-    const shouldShow = import.meta.env.PROD
+    const shouldShow = process.env.PROD
 
     const { t } = useTranslation('creator');
 

--- a/src/components/creator/Editor/ChallengeDetailsEdition/ToolBoxEditor/ToolBoxEditor.tsx
+++ b/src/components/creator/Editor/ChallengeDetailsEdition/ToolBoxEditor/ToolBoxEditor.tsx
@@ -12,7 +12,7 @@ import { availableBlocksFor, categories } from "../../../../blockly/blocks";
 
 export const ToolBoxEditor = () => {
 
-    const shouldShow = process.env.NODE_ENV !== 'production'
+    const shouldShow = import.meta.env.PROD
 
     const { t } = useTranslation('creator');
 

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -17,10 +17,10 @@ export const PBLink = (props: LinkProps & PBLinkProps) => <Link {...props} style
 
 
 const Version = () => {
-  if(!process.env.VITE_VERSION) throw new Error("Missing Pilas Bloques version. ENV not set")
+  if(!import.meta.env.VITE_VERSION) throw new Error("Missing Pilas Bloques version. ENV not set")
   const {t} = useTranslation("footer")
 
-  const appVersion = process.env.VITE_VERSION
+  const appVersion = import.meta.env.VITE_VERSION
   const newsUrl = new URL(`/novedades`, siteUrl).toString()
   const lastCommitHash = process.env.VITE_GIT_SHORT_COMMIT_HASH
   const repoUrl = `https://github.com/Program-AR/pilas-bloques-app/tree/${process.env.VITE_GIT_COMMIT_HASH}`

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -17,10 +17,10 @@ export const PBLink = (props: LinkProps & PBLinkProps) => <Link {...props} style
 
 
 const Version = () => {
-  if(!process.env.VITE_APP_VERSION) throw new Error("Missing Pilas Bloques version. ENV not set")
+  if(!process.env.VITE_VERSION) throw new Error("Missing Pilas Bloques version. ENV not set")
   const {t} = useTranslation("footer")
 
-  const appVersion = process.env.VITE_APP_VERSION
+  const appVersion = process.env.VITE_VERSION
   const newsUrl = new URL(`/novedades`, siteUrl).toString()
   const lastCommitHash = process.env.VITE_GIT_SHORT_COMMIT_HASH
   const repoUrl = `https://github.com/Program-AR/pilas-bloques-app/tree/${process.env.VITE_GIT_COMMIT_HASH}`

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -17,10 +17,10 @@ export const PBLink = (props: LinkProps & PBLinkProps) => <Link {...props} style
 
 
 const Version = () => {
-  if(!import.meta.env.VITE_VERSION) throw new Error("Missing Pilas Bloques version. ENV not set")
+  if(!process.env.VITE_VERSION) throw new Error("Missing Pilas Bloques version. ENV not set")
   const {t} = useTranslation("footer")
 
-  const appVersion = import.meta.env.VITE_VERSION
+  const appVersion = process.env.VITE_VERSION
   const newsUrl = new URL(`/novedades`, siteUrl).toString()
   const lastCommitHash = process.env.VITE_GIT_SHORT_COMMIT_HASH
   const repoUrl = `https://github.com/Program-AR/pilas-bloques-app/tree/${process.env.VITE_GIT_COMMIT_HASH}`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,8 +9,8 @@ import { ThemeContextProvider } from './theme/ThemeContext';
 import { PBProgress } from "./components/PBProgress";
 
 
-if (import.meta.env.VITE_GOOGLE_ANALYTICS_KEY) {
-  ReactGA.initialize(import.meta.env.VITE_GOOGLE_ANALYTICS_KEY);
+if (process.env.VITE_GOOGLE_ANALYTICS_KEY) {
+  ReactGA.initialize(process.env.VITE_GOOGLE_ANALYTICS_KEY);
 }
 
 const root = ReactDOM.createRoot(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,8 +9,8 @@ import { ThemeContextProvider } from './theme/ThemeContext';
 import { PBProgress } from "./components/PBProgress";
 
 
-if (process.env.VITE_GOOGLE_ANALYTICS_KEY) {
-  ReactGA.initialize(process.env.VITE_GOOGLE_ANALYTICS_KEY);
+if (import.meta.env.VITE_GOOGLE_ANALYTICS_KEY) {
+  ReactGA.initialize(import.meta.env.VITE_GOOGLE_ANALYTICS_KEY);
 }
 
 const root = ReactDOM.createRoot(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,8 +9,8 @@ import { ThemeContextProvider } from './theme/ThemeContext';
 import { PBProgress } from "./components/PBProgress";
 
 
-if (process.env.VITE_APP_GOOGLE_ANALYTICS_KEY) {
-  ReactGA.initialize(process.env.VITE_APP_GOOGLE_ANALYTICS_KEY);
+if (process.env.VITE_GOOGLE_ANALYTICS_KEY) {
+  ReactGA.initialize(process.env.VITE_GOOGLE_ANALYTICS_KEY);
 }
 
 const root = ReactDOM.createRoot(

--- a/src/pbApi.ts
+++ b/src/pbApi.ts
@@ -96,7 +96,7 @@ export namespace PilasBloquesApi{
       return isValid
     }
 
-    export const baseURL = window.PBRuntime?.apiURL || process.env.API_URL
+    export const baseURL = window.PBRuntime?.apiURL || import.meta.env.API_URL
 
     async function bodyWithContext<T>(body?: T) {
       return body ? {

--- a/src/pbApi.ts
+++ b/src/pbApi.ts
@@ -96,7 +96,7 @@ export namespace PilasBloquesApi{
       return isValid
     }
 
-    export const baseURL = window.PBRuntime?.apiURL || import.meta.env.API_URL
+    export const baseURL = window.PBRuntime?.apiURL || process.env.API_URL
 
     async function bodyWithContext<T>(body?: T) {
       return body ? {

--- a/src/pbApi.ts
+++ b/src/pbApi.ts
@@ -96,7 +96,7 @@ export namespace PilasBloquesApi{
       return isValid
     }
 
-    export const baseURL = window.PBRuntime?.apiURL || process.env.VITE_APP_API_URL
+    export const baseURL = window.PBRuntime?.apiURL || process.env.API_URL
 
     async function bodyWithContext<T>(body?: T) {
       return body ? {

--- a/src/pbSession.ts
+++ b/src/pbSession.ts
@@ -27,7 +27,7 @@ export namespace PBSession {
           online: online(),
           browserId: null,
           userId: LocalStorage.getUser(),
-          version: import.meta.env.VITE_VERSION,
+          version: process.env.VITE_VERSION,
           experimentGroup: 'off',
           url: window.location.href,
           ip: await userIp(),

--- a/src/pbSession.ts
+++ b/src/pbSession.ts
@@ -27,7 +27,7 @@ export namespace PBSession {
           online: online(),
           browserId: null,
           userId: LocalStorage.getUser(),
-          version: process.env.VITE_APP_VERSION,
+          version: process.env.VITE_VERSION,
           experimentGroup: 'off',
           url: window.location.href,
           ip: await userIp(),

--- a/src/pbSession.ts
+++ b/src/pbSession.ts
@@ -27,7 +27,7 @@ export namespace PBSession {
           online: online(),
           browserId: null,
           userId: LocalStorage.getUser(),
-          version: process.env.VITE_VERSION,
+          version: import.meta.env.VITE_VERSION,
           experimentGroup: 'off',
           url: window.location.href,
           ip: await userIp(),

--- a/src/test/shareByUrl.test.tsx
+++ b/src/test/shareByUrl.test.tsx
@@ -102,7 +102,7 @@ describe("Share by url", () => {
             await shareChallenge()
             const urlText = await screen.findByRole('textbox')
 
-            expect(urlText.getAttribute('value')).toBe(`${process.env.VITE_PB_APP_URL}/#/desafio/guardado/shared`)
+            expect(urlText.getAttribute('value')).toBe(`${import.meta.env.VITE_PB_APP_URL}/#/desafio/guardado/shared`)
         })
 
         test("Should change to save button on challenge share", async () => {
@@ -130,7 +130,7 @@ describe("Share by url", () => {
             const urlText = await screen.findByRole('textbox')
 
             //The url text is not changing in the text
-            expect(urlText.getAttribute('value')).toBe(`${process.env.VITE_PB_APP_URL}/#/desafio/guardado/newShared`)
+            expect(urlText.getAttribute('value')).toBe(`${import.meta.env.VITE_PB_APP_URL}/#/desafio/guardado/newShared`)
         })
 
     })

--- a/src/test/shareByUrl.test.tsx
+++ b/src/test/shareByUrl.test.tsx
@@ -102,7 +102,7 @@ describe("Share by url", () => {
             await shareChallenge()
             const urlText = await screen.findByRole('textbox')
 
-            expect(urlText.getAttribute('value')).toBe(`${import.meta.env.VITE_PB_APP_URL}/#/desafio/guardado/shared`)
+            expect(urlText.getAttribute('value')).toBe(`${process.env.VITE_PB_APP_URL}/#/desafio/guardado/shared`)
         })
 
         test("Should change to save button on challenge share", async () => {
@@ -130,7 +130,7 @@ describe("Share by url", () => {
             const urlText = await screen.findByRole('textbox')
 
             //The url text is not changing in the text
-            expect(urlText.getAttribute('value')).toBe(`${import.meta.env.VITE_PB_APP_URL}/#/desafio/guardado/newShared`)
+            expect(urlText.getAttribute('value')).toBe(`${process.env.VITE_PB_APP_URL}/#/desafio/guardado/newShared`)
         })
 
     })

--- a/src/test/shareByUrl.test.tsx
+++ b/src/test/shareByUrl.test.tsx
@@ -102,7 +102,7 @@ describe("Share by url", () => {
             await shareChallenge()
             const urlText = await screen.findByRole('textbox')
 
-            expect(urlText.getAttribute('value')).toBe(`${process.env.VITE_APP_PB_APP_URL}/#/desafio/guardado/shared`)
+            expect(urlText.getAttribute('value')).toBe(`${process.env.VITE_PB_APP_URL}/#/desafio/guardado/shared`)
         })
 
         test("Should change to save button on challenge share", async () => {
@@ -130,7 +130,7 @@ describe("Share by url", () => {
             const urlText = await screen.findByRole('textbox')
 
             //The url text is not changing in the text
-            expect(urlText.getAttribute('value')).toBe(`${process.env.VITE_APP_PB_APP_URL}/#/desafio/guardado/newShared`)
+            expect(urlText.getAttribute('value')).toBe(`${process.env.VITE_PB_APP_URL}/#/desafio/guardado/newShared`)
         })
 
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["node"]
+    "types": ["node", "vite/client"]
   },
   "include": [
     "src"


### PR DESCRIPTION
Dado que el problema está con el build de vite y windows (deberia tener una PC con windows y probar por qué es que hace lo que hace al realizar el build), decidí hacer que el instalador para windows se ejecute en el workflow usando linux como SO en lugar de windows-latest (que es el windows server 2022 con powershell 7) tal y como hacemos nosotros desde nuestras computadoras con linux y que con nsis y wine64 lo puede construir.
El release 2.5.7 https://github.com/Program-AR/pilas-bloques-app/releases/tag/2.5.7 tiene el instalador funcionando. Pueden probarlo por favor.
