### PR TITLE
PBLinks abren en otra pestaña

### DIFF
--- a/src/components/about/About.tsx
+++ b/src/components/about/About.tsx
@@ -12,7 +12,7 @@ export const About = () => {
         <UserCard title={t("title")} handleSubmit={() => { }}>
             <Typography className={styles.title} variant="h4"></Typography>
             <Typography>{t("text")}
-                <PBLink to="https://pilasbloques.program.ar/acerca-de-pilas-bloques/" target="_blank">{t("redirect")}</PBLink>
+                <PBLink to="https://pilasbloques.program.ar/acerca-de-pilas-bloques/">{t("redirect")}</PBLink>
             </Typography>
         </UserCard>
     </>

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -13,7 +13,7 @@ type PBLinkProps = {
   children: React.ReactNode
 }
 
-export const PBLink = (props: LinkProps & PBLinkProps) => <Link {...props} style={{color: 'var(--theme-link-color)'}}>{props.children}</Link>
+export const PBLink = (props: LinkProps & PBLinkProps) => <Link {...props} target='_blank' style={{color: 'var(--theme-link-color)'}}>{props.children}</Link>
 
 
 const Version = () => {
@@ -28,11 +28,11 @@ const Version = () => {
   return (
     <Stack direction="row" gap={0.5}>
       {t("version")}
-      <PBLink to={newsUrl} target="_blank">
+      <PBLink to={newsUrl}>
         {appVersion}
       </PBLink>
       <Code />
-      <PBLink to={repoUrl} target="_blank">
+      <PBLink to={repoUrl}>
         {lastCommitHash}
       </PBLink>
     </Stack>
@@ -42,7 +42,7 @@ const Version = () => {
 
 const Links = () => {
   const {t} = useTranslation("footer")
-  const teachersSiteUrl = new URL(`/docentes`, siteUrl).toString()
+  const teachersSiteUrl = 'https://pilasbloques.program.ar/docentes/'
 
   return (
     <Stack direction="row" gap={1}>

--- a/src/components/users/register/Register.tsx
+++ b/src/components/users/register/Register.tsx
@@ -149,7 +149,7 @@ export const Register: FC = () => {
         <Collapse style={{ padding: "10px" }} in={whyReqData}>
           <Typography>{t("whyData.privacy")}</Typography>
           <Typography>{t("whyData.dataProtectionLaw")}&nbsp;
-            <PBLink target="_blank" to={termsAndConditionsLink}>{t("linkTerms")}</PBLink></Typography>
+            <PBLink to={termsAndConditionsLink}>{t("linkTerms")}</PBLink></Typography>
           <Typography>{t("whyData.parentalContact")}&nbsp;
             <PBMailLink />&nbsp;
             {t("whyData.whyContact")}</Typography>
@@ -157,7 +157,7 @@ export const Register: FC = () => {
       </Stack>
 
       <FormControlLabel
-        label={<Typography>{t('terms')}<PBLink target="_blank" to={termsAndConditionsLink}>{t("linkTerms")}</PBLink></Typography>}
+        label={<Typography>{t('terms')}<PBLink to={termsAndConditionsLink}>{t("linkTerms")}</PBLink></Typography>}
         control={<Checkbox sx={{ color: theme.palette.primary.main }}
           onChange={() => setTermAndConditions(!termsAndConditions)}
           required />


### PR DESCRIPTION
Algunos links estaban puestos para que te abran en la misma pagina en lugar de una nueva pestaña, directamente lo puse para que el componente `PBLink` (que tiene el estilo sacado del theme) se encargue de eso asi nos despreocupamos con andar poniendo el `target='_blank` en todos lados. 
Usamos el componente `Link` en otros lugares pero justamente para cosas que se tienen que abrir en la misma pestaña (elección de un libro por ejemplo).

También aproveche a arreglar el link de la página para docentes, que en local funciona pero en producción está redirigiendo a `https://pilasbloques.program.ar/online/#/docentes`, que no existe.