### PR TITLE
Generar codigo de bloques

### DIFF
--- a/src/components/blockly/blockly.ts
+++ b/src/components/blockly/blockly.ts
@@ -1285,7 +1285,7 @@ const createOthersBlocks = (t: (key: string) => string) => {
     mutationToDom: Blockly.Blocks['variables_get'].mutationToDom,
     domToMutation: Blockly.Blocks['variables_get'].domToMutation,
     onchange: Blockly.Blocks['variables_get'].onchange,
-    categoryId: 'variables',
+    categoryId: 'myprocedures',
   };
 
   Blockly.Blocks['Procedimiento'] = {

--- a/src/components/blockly/blockly.ts
+++ b/src/components/blockly/blockly.ts
@@ -1288,14 +1288,6 @@ const createOthersBlocks = (t: (key: string) => string) => {
     categoryId: 'variables',
   };
 
-  Blockly.Blocks['param_set'] = {
-    init: Blockly.Blocks['variables_set'].init,
-    mutationToDom: Blockly.Blocks['variables_set'].mutationToDom,
-    domToMutation: Blockly.Blocks['variables_set'].domToMutation,
-    onchange: Blockly.Blocks['variables_set'].onchange,
-    categoryId: 'variables',
-  };
-
   Blockly.Blocks['Procedimiento'] = {
     init: Blockly.Blocks['procedures_defnoreturn'].init,
     setStatements_: Blockly.Blocks['procedures_defnoreturn'].setStatements_,

--- a/src/components/blockly/blockly.ts
+++ b/src/components/blockly/blockly.ts
@@ -1,7 +1,6 @@
 import { BlockType } from "./blocks"
 import Es from 'blockly/msg/es';
 import Blockly from "blockly/core"
-import { isNumber } from "blockly/core/utils/string";
 import { javascriptGenerator, Order } from 'blockly/javascript'
 import { enableUnwantedProcedureBlocks, disableUnwantedProcedureBlocks, optionType, createCommonBlocklyBlocks, validateRequiredOptions } from "./utils";
 
@@ -1235,7 +1234,7 @@ const createBlocksCode = () => {
       const loopVar = generator.nameDB_.getDistinctName(
         'count', Blockly.Names.NameType.VARIABLE);
       var endVar = repeats;
-      if (!repeats.match(/^\w+$/) && isNumber(repeats)) {
+      if (!repeats.match(/^\w+$/) && Blockly.utils.string.isNumber(repeats)) {
         endVar = generator.nameDB_.getDistinctName(
           'repeat_end', Blockly.Names.NameType.VARIABLE);
         code += 'var ' + endVar + ' = ' + repeats + ';\n';

--- a/src/components/blockly/blocks.ts
+++ b/src/components/blockly/blocks.ts
@@ -139,11 +139,6 @@ export const commonBlocks: BlockType[] = [
     categoryId: 'variables'
   },
   {
-    id: 'param_set',
-    intlId: 'variables_set',
-    categoryId: 'variables'
-  },
-  {
     id: 'Procedimiento',
     intlId: 'Procedures',
     categoryId: 'myprocedures'

--- a/src/components/blockly/blocks.ts
+++ b/src/components/blockly/blocks.ts
@@ -134,11 +134,6 @@ export const commonBlocks: BlockType[] = [
     categoryId: 'operators'
   },
   {
-    id: 'param_get',
-    intlId: 'variables_get',
-    categoryId: 'variables'
-  },
-  {
     id: 'Procedimiento',
     intlId: 'Procedures',
     categoryId: 'myprocedures'

--- a/src/components/blockly/utils.ts
+++ b/src/components/blockly/utils.ts
@@ -5,6 +5,7 @@ export type optionType = {
   'argumentos'?: string
   'funcionSensor'?: string
   'valor'?: string
+  'code'?: string
 }
 
 export const validateRequiredOptions = (name: string, options: optionType, optionsRequiredList: string[]) => {


### PR DESCRIPTION
Resolves #250 

Segun cada tipo de bloque o bloque con codigo especifico, se genera el correspondiente a cada uno para utilizarlo en la ejecucion. A diferencia de lo desarrollado en ember con Blocks[id].JavaScript (o MyLanguage), ahora se debe utilizar javascriptGenerator.forBlock[id]
