### PR TITLE
Fix codigo de bloque repetir

### DIFF
--- a/src/components/blockly/blockly.ts
+++ b/src/components/blockly/blockly.ts
@@ -1,6 +1,6 @@
 import { BlockType, categories } from "./blocks"
 import Es from 'blockly/msg/es';
-import Blockly from "blockly/core"
+import Blockly, { Block } from "blockly/core"
 import { javascriptGenerator, Order } from 'blockly/javascript'
 import { enableUnwantedProcedureBlocks, disableUnwantedProcedureBlocks } from "./utils";
 import 'blockly/blocks';
@@ -75,7 +75,7 @@ export const workspaceToCode = () => javascriptGenerator.workspaceToCode(Blockly
 const blockTypeToToolboxBlock = (block: BlockType): ToolboxBlock => ({ kind: "block", type: block.id })
 
 export const createGenericJSCode = (id: string, customCode: string) => {
-  javascriptGenerator.forBlock[id] = function (block: { getFieldValue: (arg0: string) => any; }, generator: { statementToCode: (arg0: any, arg1: string) => any; valueToCode: (arg0: any, arg1: string, arg2: any) => any; }) {
+  javascriptGenerator.forBlock[id] = function (block: Block, generator: { statementToCode: (arg0: any, arg1: string) => any; valueToCode: (arg0: Block, arg1: string, arg2: Order) => any; }) {
     let variables = customCode.match(/\$(\w+)/g);
     let code = customCode;
     if (variables) {

--- a/src/components/blockly/blockly.ts
+++ b/src/components/blockly/blockly.ts
@@ -72,7 +72,10 @@ export const setupBlockly = (container: Element, workspaceConfiguration: Blockly
 
 export const workspaceToCode = () => javascriptGenerator.workspaceToCode(Blockly.getMainWorkspace())
 
-const blockTypeToToolboxBlock = (block: BlockType): ToolboxBlock => ({ kind: "block", type: block.id })
+/**
+ * Some blocks, like "Repetir" need to be attached to a math_number block on toolbox, that's why they have toolboxJSON property
+ */
+const blockTypeToToolboxBlock = (block: BlockType): any => block.toolboxJSON ? block.toolboxJSON : { kind: "block", type: block.id }
 
 export const createGenericJSCode = (id: string, customCode: string) => {
   javascriptGenerator.forBlock[id] = function (block: Block, generator: { statementToCode: (arg0: any, arg1: string) => any; valueToCode: (arg0: Block, arg1: string, arg2: Order) => any; }) {

--- a/src/components/blockly/blocks.ts
+++ b/src/components/blockly/blocks.ts
@@ -13,7 +13,8 @@ export const categories: string[] = [
 export type BlockType = {
   id: string
   intlId: string
-  categoryId: typeof categories[number]
+  categoryId: typeof categories[number],
+  toolboxJSON?: {}
 }
 
 export const commonBlocks: BlockType[] = [
@@ -105,7 +106,21 @@ export const commonBlocks: BlockType[] = [
   {
     id: 'Repetir',
     intlId: 'repeat',
-    categoryId: 'repetitions'
+    categoryId: 'repetitions',
+    toolboxJSON: {
+      "kind": "block",
+      "type": "Repetir",
+      "inputs": {
+        "count": {
+          "block": {
+            "type": "math_number",
+            "fields": {
+              "NUM": 10
+            }
+          }
+        }
+      }
+    }
   },
   {
     id: 'Hasta',
@@ -213,7 +228,21 @@ const notUsedBlocks: BlockType[] = [
   {
     id: 'SaltarHaciaAdelante',
     intlId: 'JumpForward',
-    categoryId: 'primitives'
+    categoryId: 'primitives',
+    toolboxJSON: {
+      "kind": "block",
+      "type": "SaltarHaciaAdelante",
+      "inputs": {
+        "longitud": {
+          "block": {
+            "type": "math_number",
+            "fields": {
+              "NUM": 100
+            }
+          }
+        }
+      }
+    }
   },
   {
     id: 'EstoyEnEsquina',
@@ -298,7 +327,21 @@ const notUsedBlocks: BlockType[] = [
   {
     id: 'DibujarLado',
     intlId: 'drawSide',
-    categoryId: 'primitives'
+    categoryId: 'primitives',
+    toolboxJSON: {
+      "kind": "block",
+      "type": "DibujarLado",
+      "inputs": {
+        "longitud": {
+          "block": {
+            "type": "math_number",
+            "fields": {
+              "NUM": 100
+            }
+          }
+        }
+      }
+    }
   },
   {
     id: 'EntregarCargador',
@@ -373,7 +416,21 @@ const notUsedBlocks: BlockType[] = [
   {
     id: 'GirarGrados',
     intlId: 'rotateGrades',
-    categoryId: 'primitives'
+    categoryId: 'primitives',
+    toolboxJSON: {
+      "kind": "block",
+      "type": "GirarGrados",
+      "inputs": {
+        "longitud": {
+          "block": {
+            "type": "math_number",
+            "fields": {
+              "NUM": 100
+            }
+          }
+        }
+      }
+    }
   },
   {
     id: 'TomarLata',

--- a/src/components/blockly/blocksGallery/controlStructures.ts
+++ b/src/components/blockly/blocksGallery/controlStructures.ts
@@ -6,8 +6,8 @@ const controlColor = '#ee7d16';
 export const createControlStructureBlocks = (t: (key: string) => string) => {
 
   const repeatBlocksCode = (id: string) => {
-    javascriptGenerator.forBlock[id] = function (block: Block, generator: { valueToCode: (arg0: any, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; addLoopTrap: (arg0: any, arg1: any) => any; nameDB_: { getDistinctName: (arg0: string, arg1: Blockly.Names.NameType) => any; }; }) {
-      const repeats = block.getFieldValue('count') || '0';
+    javascriptGenerator.forBlock[id] = function (block: Block, generator: { valueToCode: (arg0: Block, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; addLoopTrap: (arg0: any, arg1: any) => any; nameDB_: { getDistinctName: (arg0: string, arg1: Blockly.Names.NameType) => any; }; }) {
+      const repeats = generator.valueToCode(block, 'count', Order.ATOMIC) || '0';
 
       var branch = generator.statementToCode(block, 'block');
       branch = generator.addLoopTrap(branch, block);
@@ -51,29 +51,9 @@ export const createControlStructureBlocks = (t: (key: string) => string) => {
   repeatBlocksCode('RepetirVacio');
 
   Blockly.Blocks['Repetir'] = {
-    init: function () {
-      this.setColour(controlColor);
-      this.setInputsInline(true);
-      this.setPreviousStatement(true);
-      this.setNextStatement(true);
-      this.appendDummyInput()
-        .appendField(t('blocks.repeat'))
-      this.jsonInit({
-        message0: `%1`,
-        args0: [
-          {
-            "type": "field_number",
-            "name": 'count',
-            "value": 10,
-          }
-        ]
-      })
-      this.appendDummyInput()
-        .appendField(t('blocks.times'));
-      this.appendStatementInput('block');
-    },
-    categoryId: 'repetitions',
-  };
+    init: Blockly.Blocks['RepetirVacio'].init,
+    categoryId: Blockly.Blocks['RepetirVacio'].categoryId,
+  }
 
   repeatBlocksCode('Repetir');
 
@@ -91,7 +71,7 @@ export const createControlStructureBlocks = (t: (key: string) => string) => {
     categoryId: 'repetitions',
   };
 
-  javascriptGenerator.forBlock['Hasta'] = function (block: any, generator: { valueToCode: (arg0: any, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; }) {
+  javascriptGenerator.forBlock['Hasta'] = function (block: Block, generator: { valueToCode: (arg0: Block, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; }) {
     const condition = generator.valueToCode(block, 'condition', Order.ASSIGNMENT) || 'false';
     const contenido = generator.statementToCode(block, 'block');
     return `while (!${condition}) {
@@ -113,7 +93,7 @@ export const createControlStructureBlocks = (t: (key: string) => string) => {
     categoryId: 'alternatives',
   };
 
-  javascriptGenerator.forBlock['Si'] = function (block: any, generator: { valueToCode: (arg0: any, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; }) {
+  javascriptGenerator.forBlock['Si'] = function (block: Block, generator: { valueToCode: (arg0: Block, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; }) {
     const condition = generator.valueToCode(block, 'condition', Order.ATOMIC) || 'false';
     const contenido = generator.statementToCode(block, 'block');
     return `if (${condition}) {
@@ -138,7 +118,7 @@ export const createControlStructureBlocks = (t: (key: string) => string) => {
     categoryId: 'alternatives',
   };
 
-  javascriptGenerator.forBlock['SiNo'] = function (block: any, generator: { valueToCode: (arg0: any, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; }) {
+  javascriptGenerator.forBlock['SiNo'] = function (block: Block, generator: { valueToCode: (arg0: Block, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; }) {
     const condition = generator.valueToCode(block, 'condition', Order.ASSIGNMENT) || 'false';
     const bloque_1 = generator.statementToCode(block, 'block1');
     const bloque_2 = generator.statementToCode(block, 'block2');

--- a/src/components/blockly/blocksGallery/controlStructures.ts
+++ b/src/components/blockly/blocksGallery/controlStructures.ts
@@ -45,14 +45,14 @@ export const createControlStructureBlocks = (t: (key: string) => string) => {
         .appendField(t('blocks.times'));
       this.appendStatementInput('block');
     },
-    categoryId: 'repetitions',
+    categoryId: 'repetitions'
   };
 
   repeatBlocksCode('RepetirVacio');
 
   Blockly.Blocks['Repetir'] = {
     init: Blockly.Blocks['RepetirVacio'].init,
-    categoryId: Blockly.Blocks['RepetirVacio'].categoryId,
+    categoryId: Blockly.Blocks['RepetirVacio'].categoryId
   }
 
   repeatBlocksCode('Repetir');

--- a/src/components/blockly/blocksGallery/controlStructures.ts
+++ b/src/components/blockly/blocksGallery/controlStructures.ts
@@ -1,4 +1,4 @@
-import Blockly from "blockly/core"
+import Blockly, { Block } from "blockly/core"
 import { javascriptGenerator, Order } from "blockly/javascript";
 
 const controlColor = '#ee7d16';
@@ -6,17 +6,17 @@ const controlColor = '#ee7d16';
 export const createControlStructureBlocks = (t: (key: string) => string) => {
 
   const repeatBlocksCode = (id: string) => {
-    javascriptGenerator.forBlock[id] = function (block: { id: any; }, generator: { valueToCode: (arg0: any, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; addLoopTrap: (arg0: any, arg1: any) => any; nameDB_: { getDistinctName: (arg0: string, arg1: Blockly.Names.NameType) => any; }; }) {
-      const repeats = generator.valueToCode(block, 'count', Order.ASSIGNMENT) || '0';
+    javascriptGenerator.forBlock[id] = function (block: Block, generator: { valueToCode: (arg0: any, arg1: string, arg2: Order) => string; statementToCode: (arg0: any, arg1: string) => any; addLoopTrap: (arg0: any, arg1: any) => any; nameDB_: { getDistinctName: (arg0: string, arg1: Blockly.Names.NameType) => any; }; }) {
+      const repeats = block.getFieldValue('count') || '0';
 
       var branch = generator.statementToCode(block, 'block');
-      branch = generator.addLoopTrap(branch, block.id);
+      branch = generator.addLoopTrap(branch, block);
       var code = '';
 
       const loopVar = generator.nameDB_.getDistinctName(
         'count', Blockly.Names.NameType.VARIABLE);
       var endVar = repeats;
-      if (!repeats.match(/^\w+$/) && Blockly.utils.string.isNumber(repeats)) {
+      if (!repeats.toString().match(/^\w+$/) && Blockly.utils.string.isNumber(repeats)) {
         endVar = generator.nameDB_.getDistinctName(
           'repeat_end', Blockly.Names.NameType.VARIABLE);
         code += 'var ' + endVar + ' = ' + repeats + ';\n';

--- a/src/components/blockly/blocksGallery/others.ts
+++ b/src/components/blockly/blocksGallery/others.ts
@@ -1,5 +1,5 @@
 import { createCommonBlocklyBlocks } from "../utils";
-import Blockly from "blockly/core"
+import Blockly, { Block } from "blockly/core"
 import { sensorsColor } from "./sensors";
 import { javascriptGenerator, Order } from "blockly/javascript";
 
@@ -73,8 +73,8 @@ export const createOthersBlocks = (t: (key: string) => string) => {
         categoryId: 'operators'
     };
 
-    javascriptGenerator.forBlock['OpAritmetica'] = function (block: { getFieldValue: (arg0: string) => any; }, generator: { valueToCode: (arg0: any, arg1: string, arg2: any) => string; }) {
-        // Basic arithmetic operators, and power.    
+    javascriptGenerator.forBlock['OpAritmetica'] = function (block: Block, generator: { valueToCode: (arg0: Block, arg1: string, arg2: any) => string; }) {
+        // Basic arithmetic operators, and power.   
         const OPERATORS = {
             'ADD': [' + ', Order.ADDITION],
             'MINUS': [' - ', Order.SUBTRACTION],

--- a/src/components/blockly/values.ts
+++ b/src/components/blockly/values.ts
@@ -1,101 +1,81 @@
 import { javascriptGenerator, Order } from "blockly/javascript";
 import { BlocklyBlockDefinition, messageBlock } from "./blockly";
 import { optionType, validateRequiredOptions } from "./utils";
-import Blockly from "blockly/core"
+import Blockly, { Block } from "blockly/core"
 
 const directionsColor = '#2ba4e2';
 
 const createValueBlock = (id: string, message: string, options: optionType, icon: string, blockDefinition?: BlocklyBlockDefinition) => {
-    validateRequiredOptions(id, options, ['valor']);
-  
-    const jsonInit: BlocklyBlockDefinition = (blockDefinition ? blockDefinition : {
-      message0: `${message}`,
-      colour: directionsColor,
-      args0: [],
-      output: 'String'
+  validateRequiredOptions(id, options, ['valor']);
+
+  const jsonInit: BlocklyBlockDefinition = (blockDefinition ? blockDefinition : {
+    message0: `${message}`,
+    colour: directionsColor,
+    args0: [],
+    output: 'String'
+  })
+
+  if (icon) {
+    jsonInit.message0 = messageBlock(message)
+    jsonInit.args0.push({
+      "type": "field_image",
+      "src": `imagenes/iconos/${icon}`,
+      "width": 16,
+      "height": 16,
+      "alt": "*"
     })
-  
-    if (icon) {
-      jsonInit.message0 = messageBlock(message)
-      jsonInit.args0.push({
-        "type": "field_image",
-        "src": `imagenes/iconos/${icon}`,
-        "width": 16,
-        "height": 16,
-        "alt": "*"
-      })
-    }
-  
-    Blockly.Blocks[id] = {
-      init: function () {
-        this.jsonInit(jsonInit)
-      }
-    }
-  
-    javascriptGenerator.forBlock[id] = function () {
-      return [`'${options.valor}'`, Order.ATOMIC];
-    };
-  
   }
+
+  Blockly.Blocks[id] = {
+    init: function () {
+      this.jsonInit(jsonInit)
+    }
+  }
+
+  javascriptGenerator.forBlock[id] = function () {
+    return [`'${options.valor}'`, Order.ATOMIC];
+  };
+
+}
 
 export const createValueBlocks = (t: (key: string) => string) => {
 
-    createValueBlock("ParaLaDerecha", t('blocks.right'), {
-      valor: 'derecha',
-    }, 'icono.derecha.png',
-    );
-  
-    createValueBlock('ParaLaIzquierda', t('blocks.left'), {
-      valor: 'izquierda',
-    }, 'icono.izquierda.png',
-    );
-  
-    createValueBlock('ParaArriba', t('blocks.up'), {
-      valor: 'arriba',
-    }, 'icono.arriba.png',
-    );
-  
-    createValueBlock('ParaAbajo', t('blocks.down'), {
-      valor: 'abajo',
-    }, 'icono.abajo.png',
-    );
-  
-    createValueBlock('Booleano', t('blocks.boolean'), { valor: '' }, '',
-      {
-        message0: t('blocks.boolean'),
-        colour: directionsColor,
-        type: 'logic_boolean',
-        args0: [],
-        output: 'Boolean'
-      })
-  
-    createValueBlock('Numero', t('blocks.number'), { valor: '' }, '',
-      {
-        message0: `%1`,
-        colour: directionsColor,
-        inputsInline: true,
-        args0: [
-          {
-            "type": "field_number",
-            "name": t('blocks.number'),
-            "value": 0,
-          }
-        ],
-        output: 'Number'
-      })
-  
-    createValueBlock('Texto', t('blocks.text'), { valor: '' }, '',
-      {
-        message0: `%1`,
-        colour: directionsColor,
-        inputsInline: true,
-        args0: [
-          {
-            "type": "field_input",
-            "name": t('blocks.text'),
-            "text": ''
-          }
-        ],
-        output: 'String'
-      })
+  createValueBlock("ParaLaDerecha", t('blocks.right'), {
+    valor: 'derecha',
+  }, 'icono.derecha.png',
+  );
+
+  createValueBlock('ParaLaIzquierda', t('blocks.left'), {
+    valor: 'izquierda',
+  }, 'icono.izquierda.png',
+  );
+
+  createValueBlock('ParaArriba', t('blocks.up'), {
+    valor: 'arriba',
+  }, 'icono.arriba.png',
+  );
+
+  createValueBlock('ParaAbajo', t('blocks.down'), {
+    valor: 'abajo',
+  }, 'icono.abajo.png',
+  );
+
+
+  Blockly.Blocks['Booleano'] = {
+    init: Blockly.Blocks['logic_boolean'].init,
+    categoryId: Blockly.Blocks['logic_boolean'].categoryId,
   }
+
+  javascriptGenerator.forBlock['Numero'] = function (block: Block) {
+    return [`${(block.getFieldValue('BOOL') == 'TRUE') ? 'true' : 'false'}`, Order.ATOMIC];
+  }
+
+  Blockly.Blocks['Numero'] = {
+    init: Blockly.Blocks['math_number'].init,
+    categoryId: Blockly.Blocks['math_number'].categoryId,
+  }
+
+  javascriptGenerator.forBlock['Numero'] = function (block: Block) {
+    return [`${block.getFieldValue('NUM')}`, Order.ATOMIC];
+  };
+}

--- a/src/components/blockly/values.ts
+++ b/src/components/blockly/values.ts
@@ -66,7 +66,7 @@ export const createValueBlocks = (t: (key: string) => string) => {
     categoryId: Blockly.Blocks['logic_boolean'].categoryId,
   }
 
-  javascriptGenerator.forBlock['Numero'] = function (block: Block) {
+  javascriptGenerator.forBlock['Booleano'] = function (block: Block) {
     return [`${(block.getFieldValue('BOOL') == 'TRUE') ? 'true' : 'false'}`, Order.ATOMIC];
   }
 


### PR DESCRIPTION
Related #251 

Repliqué el bloque que está hoy en producción, que tenga el bloquesito del valor dentro en lugar de el input de número.
La razón por la cuál no estaba andando es porque los bloques de valores tenían hardcodeado que escupan un sting vacío en lugar de un valor. 
Aproveché también a cambiar algunos tipos que faltaban.

https://github.com/user-attachments/assets/8e4db912-b71a-4565-a48c-79ba86d7c898