### PR TITLE
Más datos para el Google Analytics

### DIFF
--- a/src/components/challengeView/ChallengeView.tsx
+++ b/src/components/challengeView/ChallengeView.tsx
@@ -53,6 +53,7 @@ export const ChallengeView = ({ path, height, serializedChallenge }: ChallengeVi
       predefinedSolution: sc.predefinedSolution,
       shouldShowMultipleScenarioHelp: (sc.scene.maps.length > 1),
       id: 0,
+      title: sc.title,
       imageURL: () => `imagenes/sceneImages/${sc.scene.type}/tool.png`
     }
   )

--- a/src/components/challengeView/SceneButtons/useInterpreterRunner.ts
+++ b/src/components/challengeView/SceneButtons/useInterpreterRunner.ts
@@ -33,19 +33,23 @@ export const useInterpreterRunner = (
   const [mulangResults, setMulangResults] = useState<MulangExpectationResult[]>([]);
   const [solved, setSolved] = useState(false);
 
-  const trackExecutionEvent = useCallback((eventType: 'run' | 'success' | 'failure') => {
+  const trackExecutionEvent = useCallback((eventType: 'run' | 'success' | 'success_with_warnings' | 'failure', failedExpectations?: string) => {
     const isOfficial = challenge.id !== 0;
     const actionMap = {
       run: isOfficial ? "run_challenge" : "creator_challenge_run",
       success: isOfficial ? "challenge_success" : "creator_challenge_success",
+      success_with_warnings: isOfficial ? "challenge_success_with_warnings" : "creator_challenge_success_with_warnings",
       failure: isOfficial ? "challenge_failure" : "creator_challenge_failure"
     };
 
-    ReactGA.event({
-        category: isOfficial ? "execution" : "creator_execution",
-        action: actionMap[eventType],
-        label: isOfficial ? challenge.id.toString() : challenge.title
-    });
+    const params: Record<string, string> = {
+      event_category: isOfficial ? "execution" : "creator_execution",
+      event_label: isOfficial ? challenge.id.toString() : challenge.title ?? "",
+    };
+
+    if (failedExpectations) params.failed_expectations = failedExpectations;
+
+    ReactGA.event(actionMap[eventType], params);
   }, [challenge]);
 
   useEffect(() => {
@@ -63,7 +67,7 @@ export const useInterpreterRunner = (
     }
   }, []);
 
-  const executeUntilEnd = useCallback((): Promise<void> => {
+  const executeUntilEnd = useCallback((currentMulangResults: MulangExpectationResult[] = []): Promise<void> => {
     return new Promise(async (resolve, reject) => {
       let solutionId: string | undefined;
       setRunning && setRunning(true);
@@ -102,7 +106,7 @@ export const useInterpreterRunner = (
           setStepping(false);
           interpreterFactory.clearHighlight();
 
-          checkProblemSolved().then(async (solved) => {
+          checkProblemSolved(currentMulangResults).then(async (solved) => {
             const staticAnalysis = { couldExecute: true };
             if (solutionId) await PilasBloquesApi.executionFinishedEvent(solutionId, staticAnalysis, solved);
             resolve();
@@ -122,11 +126,25 @@ export const useInterpreterRunner = (
     });
   }, [challenge, mode, setRunning, getBlocklyXML]);
 
-  const checkProblemSolved = async () => {
+  const checkProblemSolved = async (currentMulangResults: MulangExpectationResult[]) => {
     const solved = await scene.isTheProblemSolved();    
     setSolved(solved);
 
-    trackExecutionEvent(solved ? 'success' : 'failure');
+    let outcome: 'success' | 'success_with_warnings' | 'failure' = 'failure';
+    let failedExpectationsString = "";
+
+    if (solved) {
+       const failedExpectations = currentMulangResults.filter(req => req.result === false);
+       if (failedExpectations.length > 0) {
+           outcome = 'success_with_warnings';
+           // Join the IDs of the failed expectations (e.g. "Uses Simple Repetition")
+           failedExpectationsString = failedExpectations.map(req => req.id).join(', ');
+       } else {
+           outcome = 'success';
+       }
+    }
+    
+    trackExecutionEvent(outcome, failedExpectationsString);
 
     if (solved) setShowModal(true);
     return solved;
@@ -144,7 +162,7 @@ export const useInterpreterRunner = (
 
       setMulangResults(validationResult?.mulangResults || [])
 
-      executeUntilEnd();
+      executeUntilEnd(validationResult?.mulangResults || []);
 
     }
   }, [executeUntilEnd, mode, stepping, options, trackExecutionEvent]);

--- a/src/components/challengeView/SceneButtons/useInterpreterRunner.ts
+++ b/src/components/challengeView/SceneButtons/useInterpreterRunner.ts
@@ -6,6 +6,7 @@ import { Challenge } from "../../../staticData/challenges";
 import { PilasBloquesApi } from "../../../pbApi";
 import Blockly from "blockly/core"
 import { MulangExpectationResult } from "../../blockly/mulang/mulangResults";
+import ReactGA from "react-ga4";
 
 type Mode = 'run' | 'step';
 
@@ -109,6 +110,13 @@ export const useInterpreterRunner = (
   const checkProblemSolved = async () => {
     const solved = await scene.isTheProblemSolved();    
     setSolved(solved);
+
+    ReactGA.event({
+        category: "execution",
+        action: solved ? "challenge_success" : "challenge_failure",
+        label: challenge.title || challenge.id.toString()
+    });
+
     if (solved) setShowModal(true);
     return solved;
   };
@@ -120,6 +128,12 @@ export const useInterpreterRunner = (
       const validationResult = await options?.runValidations?.();
 
       if (validationResult?.canRun === false) return;
+
+      ReactGA.event({
+          category: "execution",
+          action: "run_challenge",
+          label: challenge.title || challenge.id.toString()
+      });
 
       setMulangResults(validationResult?.mulangResults || [])
 

--- a/src/components/challengeView/SceneButtons/useInterpreterRunner.ts
+++ b/src/components/challengeView/SceneButtons/useInterpreterRunner.ts
@@ -33,6 +33,21 @@ export const useInterpreterRunner = (
   const [mulangResults, setMulangResults] = useState<MulangExpectationResult[]>([]);
   const [solved, setSolved] = useState(false);
 
+  const trackExecutionEvent = useCallback((eventType: 'run' | 'success' | 'failure') => {
+    const isOfficial = challenge.id !== 0;
+    const actionMap = {
+      run: isOfficial ? "run_challenge" : "creator_challenge_run",
+      success: isOfficial ? "challenge_success" : "creator_challenge_success",
+      failure: isOfficial ? "challenge_failure" : "creator_challenge_failure"
+    };
+
+    ReactGA.event({
+        category: isOfficial ? "execution" : "creator_execution",
+        action: actionMap[eventType],
+        label: isOfficial ? challenge.id.toString() : challenge.title
+    });
+  }, [challenge]);
+
   useEffect(() => {
     interpreterRef.current = null;
     setStepping(false);
@@ -111,11 +126,7 @@ export const useInterpreterRunner = (
     const solved = await scene.isTheProblemSolved();    
     setSolved(solved);
 
-    ReactGA.event({
-        category: "execution",
-        action: solved ? "challenge_success" : "challenge_failure",
-        label: challenge.title || challenge.id.toString()
-    });
+    trackExecutionEvent(solved ? 'success' : 'failure');
 
     if (solved) setShowModal(true);
     return solved;
@@ -129,18 +140,14 @@ export const useInterpreterRunner = (
 
       if (validationResult?.canRun === false) return;
 
-      ReactGA.event({
-          category: "execution",
-          action: "run_challenge",
-          label: challenge.title || challenge.id.toString()
-      });
+      trackExecutionEvent('run');
 
       setMulangResults(validationResult?.mulangResults || [])
 
       executeUntilEnd();
 
     }
-  }, [executeUntilEnd, mode, stepping, options]);
+  }, [executeUntilEnd, mode, stepping, options, trackExecutionEvent]);
 
   return {
     run,

--- a/src/components/creator/Editor/ActionButtons/DownloadButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/DownloadButton.tsx
@@ -2,6 +2,7 @@ import { SerializedChallenge } from "../../../serializedChallenge";
 import { LocalStorage } from "../../../../localStorage";
 import { CreatorActionButton } from "./CreatorActionButton";
 import DownloadIcon from '@mui/icons-material/Download';
+import ReactGA from "react-ga4";
 
 export const DownloadButton = () => {
     
@@ -12,6 +13,11 @@ export const DownloadButton = () => {
 const downloadChallenge = () => {
     const challenge: SerializedChallenge = LocalStorage.getCreatorChallenge()!
   
+    ReactGA.event({
+        category: "creator",
+        action: "download_challenge"
+    });
+
     const blob = new Blob([JSON.stringify(challenge)], { type: 'application/json' });
   
     const temporaryAnchorElement = document.createElement('a')

--- a/src/components/creator/Editor/ActionButtons/ShareChallenge/ShareModalButtons.tsx
+++ b/src/components/creator/Editor/ActionButtons/ShareChallenge/ShareModalButtons.tsx
@@ -12,6 +12,7 @@ import { DialogSnackbar } from '../../../../dialogSnackbar/DialogSnackbar';
 import { useTranslation } from 'react-i18next';
 import { SerializedChallenge } from '../../../../serializedChallenge';
 import { DownloadButton } from '../DownloadButton';
+import ReactGA from "react-ga4";
 
 export const CopyToClipboardButton = ({ textToCopy }: { textToCopy: string }) => {
 
@@ -67,6 +68,11 @@ export const ChallengeUpsertButton = ({ Icon, challengeUpsert, nametag }: { Icon
             const savedChallenge = await challengeUpsert(LocalStorage.getCreatorChallenge()!)
             setSharedId(savedChallenge.sharedId!)
             setSavedSnackbarOpen(true)
+
+            ReactGA.event({
+                category: "creator",
+                action: nametag === 'save' ? "update_shared_challenge" : "share_new_challenge"
+            });
         }
         catch (error) {
             setServerError(true)

--- a/src/components/header/ChangeLanguageButton.tsx
+++ b/src/components/header/ChangeLanguageButton.tsx
@@ -2,6 +2,7 @@ import {IconButton, Menu, MenuItem} from "@mui/material";
 import LanguageIcon from '@mui/icons-material/Language';
 import React from "react";
 import { availableLanguages, changeLanguage, InternalizationLanguage } from "../../language";
+import ReactGA from "react-ga4";
 
 export const ChangeLanguageButton = () => {
     const [anchorElement, setAnchorElement] = React.useState<null | HTMLElement>(null);
@@ -16,6 +17,11 @@ export const ChangeLanguageButton = () => {
     }
 
     const handleLanguageSelection = (selectedLanguage: InternalizationLanguage) => {
+      ReactGA.event({
+          category: "localization",
+          action: "language_changed",
+          label: selectedLanguage.languageCode
+      });
       changeLanguage(selectedLanguage)
       closeMenu()
     };

--- a/src/components/users/login/LoginModal.tsx
+++ b/src/components/users/login/LoginModal.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { PilasBloquesApi } from "../../../pbApi";
 import { DialogSnackbar } from "../../dialogSnackbar/DialogSnackbar";
 import { useThemeContext } from "../../../theme/ThemeContext";
+import ReactGA from "react-ga4";
 
 export type LoginModalProps = {
     open: boolean
@@ -27,6 +28,10 @@ export const LoginModal:FC<LoginModalProps> = ({open, onClose}) => {
         const credentials = {username, password}
         try{
            await PilasBloquesApi.login(credentials)
+           ReactGA.event({
+               category: "authentication",
+               action: "login_success"
+           });
            handleOnClose()
         }catch(error: any){
             if (error.status === 400){

--- a/src/staticData/challenges.ts
+++ b/src/staticData/challenges.ts
@@ -9,6 +9,7 @@ export class Challenge {
    * Used to access the challenge by URL.
    */
   id!: number
+  title?: string
   /**
    * The pilasweb framework's scene for the challenge.
    * Scene class name or scene string initializer e.g. "new Scene..."


### PR DESCRIPTION
# Nuevos Eventos de Analytics

La plataforma ahora enviará información clave sobre el comportamiento de los usuarios directamente a Google Analytics. A continuación el detalle de los eventos implementados:

### Ejecución de Desafíos (`useInterpreterRunner.ts`)
Se agregaron tres eventos que ayudarán a evaluar la dificultad y el "engagement" del material pedagógico:
- **run_challenge**: Se dispara cada vez que el usuario hace clic en el botón "Ejecutar".
- **challenge_success**: Se dispara cuando la ejecución termina y el usuario logró resolver el desafío.
- **challenge_success_with_warnings**: Se dispara cuando el problema se resolvió, pero no se cumplieron todas las expectativas.
- **challenge_failure**: Se dispara cuando la ejecución termina pero el programa no cumple el objetivo o tiene algún error.
*(En todos estos eventos, se envía como 'Etiqueta' (Label) el título o ID del desafío para saber exactamente a cuál se refieren).*
*(Además, en `challenge_success_with_warnings` se incluye el parámetro custom `failed_expectations` con los IDs de las expectativas que fallaron, separados por coma. Esto permite ver en Analytics, sin necesidad de cruzar datos con la base de datos, cuáles son los conceptos más ignorados por los alumnos).*

> [!NOTE]
> **Filtro de Ruido Analítico:** Para mantener los datos 100% limpios, las métricas de ejecución están aisladas en dos embudos distintos:
> - **Desafíos Oficiales:** (ID > 0) Usan los eventos `run_challenge`, `challenge_success`, `challenge_success_with_warnings` y `challenge_failure` bajo la categoría `execution`. 
> - **Desafíos de la Comunidad:** (Previsualizaciones e importados) Usan eventos paralelos (`creator_challenge_run`, `creator_challenge_success`, `creator_challenge_success_with_warnings`, `creator_challenge_failure`) bajo la categoría `creator_execution`.

> [!IMPORTANT]
> **Bug de Stale Closure resuelto:** El evento `challenge_success_with_warnings` inicialmente siempre reportaba `success`, porque `checkProblemSolved` leía el estado de React `mulangResults` desde un closure capturado al inicio de la ejecución (cuando todavía estaba vacío). La solución fue pasar los resultados de Mulang como parámetro explícito a través de la cadena `run → executeUntilEnd(mulangResults) → checkProblemSolved(mulangResults)`, evitando así depender del estado asincrónico. Los resultados de Mulang viajan "de la mano" con la ejecución desde el inicio hasta el final.

> [!IMPORTANT]
> **Firma correcta de `ReactGA.event()` para parámetros custom:** La librería `react-ga4` tiene dos formas de llamar al método `event()`. La forma con un único objeto `{ action, category, label, ...extra }` **solo envía los campos estándar** e ignora silenciosamente cualquier campo adicional. Para que los parámetros custom (como `failed_expectations`) lleguen efectivamente al payload de GA4 como `ep.failed_expectations`, hay que usar la firma alternativa: `ReactGA.event("nombre_evento", { event_category, event_label, ...params_custom })`. Este fue el cambio que permitió que el parámetro finalmente apareciera en la red.


### Creador de Desafíos (`DownloadButton.tsx` y `ShareModalButtons.tsx`)
Se incorporaron métricas para medir el uso de la herramienta de creación:
- **download_challenge**: Cuenta cuántos desafíos personalizados se exportan como archivo local.
- **share_new_challenge**: Mide la adopción de la función "Compartir por link", contando cuántas veces un usuario genera un link público por primera vez.
- **update_shared_challenge**: Mide la frecuencia con la que los usuarios vuelven a actualizar o corregir un desafío que ya habían compartido previamente.

### Autenticación (`LoginModal.tsx`)
- **login_success**: Se dispara cuando un usuario ingresa sus credenciales y el servidor las valida exitosamente. 

### Localización e Idiomas (`ChangeLanguageButton.tsx`)
- **language_changed**: Se dispara cuando un usuario selecciona otro idioma en el selector del menú superior.

> [!TIP]
> Una vez en producción, se van a poder ver estos datos agrupados yendo a **Informes > Interacción > Eventos** en tu panel de Google Analytics. Estos eventos aparecerán con las categorías `execution`, `creator`, `authentication` y `localization`.
